### PR TITLE
fix: update Gemini model to 2.0-flash to resolve API errors

### DIFF
--- a/actions/cars.js
+++ b/actions/cars.js
@@ -21,7 +21,7 @@ export async function processCarImageWithAI(file) {
       throw new Error("Gemini API key is not set");
     }
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
 
     const base64Image = await fileToBase64(file);
     const imagePart = {
@@ -319,7 +319,6 @@ export async function deleteCar(id) {
     };
   }
 }
-
 
 // Update car status or featured status
 export async function updateCarStatus(id, { status, featured }) {

--- a/actions/home.js
+++ b/actions/home.js
@@ -58,7 +58,7 @@ export async function processImageSearch(file) {
     }
 
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
 
     const base64Image = await fileToBase64(file);
     const imagePart = {


### PR DESCRIPTION
Switched generative model from "gemini-1.5" to "gemini-2.0-flash" to fix compatibility issues with the genAI client. This resolves runtime errors and ensures alignment with the latest supported model version.
